### PR TITLE
Allow for more output labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,20 @@ UNet:
   UNetUpBlock(256, 64)
 ```
 
-To default input channel dimension is expected to be `1` ie. grayscale. To support different channel images, you can pass the `channels` to `Unet`.
+The default input channel dimension is expected to be `1` ie. grayscale. To support different channel images, you can pass the `channels` to `Unet`.
 
 ```julia
 julia> u = Unet(3) # for RGB images
 ```
 
 The input size can be any power of two sized batch. Something like `(256,256, channels, batch_size)`.
+
+The default output channel dimension is the input channel dimension. So, `1` for a `Unet()` and e.g. `3` for a `Unet(3)`.
+The output channel dimension can be set by supplying a second argument:
+
+```julia
+julia> u = Unet(3, 5) # 3 input channels, 5 output channels.
+```
 
 ## GPU Support
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -33,9 +33,10 @@ function (u::UNetUpBlock)(x, bridge)
 end
 
 """
-    Unet(channels::Int = 1)
+    Unet(channels::Int = 1, labels::Int = channels)
 
-  Initializes a [UNet](https://arxiv.org/pdf/1505.04597.pdf) instance with the given number of channels, typically equal to the number of channels in the input images.
+  Initializes a [UNet](https://arxiv.org/pdf/1505.04597.pdf) instance with the given number of `channels`, typically equal to the number of channels in the input images.
+  `labels`, equal to the number of input channels by default, specifies the number of output channels.
 """
 struct Unet
   conv_down_blocks

--- a/src/model.jl
+++ b/src/model.jl
@@ -45,7 +45,7 @@ end
 
 @functor Unet
 
-function Unet(channels::Int = 1)
+function Unet(channels::Int = 1, labels::Int = channels)
   conv_down_blocks = Chain(ConvDown(64,64),
 		      ConvDown(128,128),
 		      ConvDown(256,256),
@@ -64,7 +64,7 @@ function Unet(channels::Int = 1)
 		UNetUpBlock(512, 128),
 		UNetUpBlock(256, 64,p = 0.0f0),
 		Chain(x->leakyrelu.(x,0.2f0),
-		Conv((1, 1), 128=>channels;init=_random_normal)))									  
+		Conv((1, 1), 128=>labels;init=_random_normal)))									  
   Unet(conv_down_blocks, conv_blocks, up_blocks)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,10 @@ using UNet.Flux, UNet.Flux.Zygote
 
     @test size(u(ip)) == size(ip)
   end
+
+  u = Unet(2,5)
+  ip = rand(Float32, 256, 256, 2, 1)
+  @test size(u(ip)) == (256, 256, 5, 1) 
 end
 
 @testset "Variable Sizes" begin


### PR DESCRIPTION
This should not interfere with default behavior but allows one to segment an image with a different amount of classes than the number of input channels.